### PR TITLE
Fix usage of StreamReader in ReplaceToken build task

### DIFF
--- a/inc/Transform.targets
+++ b/inc/Transform.targets
@@ -24,10 +24,12 @@ See the LICENSE.txt file in the project root for more information.
     </ParameterGroup>
     <Task>
       <Reference Include="System.IO" />
+      <Reference Include="System.IO.FileSystem.Primitives" />
       <Reference Include="System.Runtime.Extensions" />
       <Reference Include="System.Text.Encoding" />
       <Reference Include="$(MSBuildToolsPath)\Microsoft.Build.Utilities.Core.dll" />
       <Using Namespace="System" />
+      <Using Namespace="System.IO" />
       <Using Namespace="System.Text" />
       <Using Namespace="Microsoft.Build.Utilities" />
       <Code Type="Fragment" Language="C#">
@@ -38,7 +40,8 @@ See the LICENSE.txt file in the project root for more information.
           Encoding encoding;
 
           var path = InputFiles[i].ItemSpec;
-          using (var reader = new StreamReader(path, Encoding.UTF8, true))
+          using (var stream = File.Open(path, FileMode.Open, FileAccess.Read, FileShare.Read))
+          using (var reader = new StreamReader(stream, Encoding.UTF8, true))
           {
             content = reader.ReadToEnd();
             encoding = reader.CurrentEncoding;


### PR DESCRIPTION
The only error I was getting on your code base was a compiler error in the RoslynCodeTaskFactory.

```
error CS1503: Argument 1: cannot convert from 'string' to 'System.IO.Stream'
```

On .NET Core, the `StreamReader` class only takes a `Stream`.

With this change:

```
D:\Temp\RestartManager\src\RestartManager.PowerShell>dotnet build
Microsoft (R) Build Engine version 15.5.153.27799 for .NET Core
Copyright (C) Microsoft Corporation. All rights reserved.

  RestartManager.PowerShell -> D:\Temp\RestartManager\src\RestartManager.PowerShell\bin\Debug\RestartManager.PowerShell.dll

Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:00:04.12
```